### PR TITLE
Add output name to finalized run dependencies

### DIFF
--- a/src/render/resolved_dependencies.rs
+++ b/src/render/resolved_dependencies.rs
@@ -959,7 +959,7 @@ pub(crate) async fn resolve_dependencies(
     if run_specs.depends.is_empty() && run_specs.constraints.is_empty() {
         tracing::info!("\nFinalized run dependencies: this output has no run dependencies");
     } else {
-        tracing::info!("\nFinalized run dependencies:\n{}", run_specs);
+        tracing::info!("\nFinalized run dependencies ({}):\n{}", output.name().as_normalized(), run_specs);
     }
 
     Ok(FinalizedDependencies {


### PR DESCRIPTION
Resolves #1486

I don't really know Rust, so there might be a better way to do this, but it works on my machine :)
